### PR TITLE
Fix: Adjust heading font sizes in Tailwind CSS

### DIFF
--- a/style/tailwind.css
+++ b/style/tailwind.css
@@ -4,20 +4,20 @@
 /** tailwind over-rides */
 
 h1 {
-  font-size: xx-large; /* Changed from xxx-large */
+  font-size: xxx-large;
   font-weight: bold;
 }
 h2 {
-  font-size: x-large;  /* Changed from xxx-large */
+  font-size: xx-large;
   font-weight: bold;
 }
 h3 {
-  font-size: large;   /* Changed from xx-large */
+  font-size: x-large;
   font-weight: bold;
 }
 
 h4 {
-  font-size: medium; /* Changed from x-large */
+  font-size: large;
   font-weight: bold;
 }
 

--- a/style/tailwind.css
+++ b/style/tailwind.css
@@ -3,18 +3,21 @@
 @import "tailwindcss/utilities";
 /** tailwind over-rides */
 
-h1,
+h1 {
+  font-size: xx-large; /* Changed from xxx-large */
+  font-weight: bold;
+}
 h2 {
-  font-size: xxx-large;
+  font-size: x-large;  /* Changed from xxx-large */
   font-weight: bold;
 }
 h3 {
-  font-size: xx-large;
+  font-size: large;   /* Changed from xx-large */
   font-weight: bold;
 }
 
 h4 {
-  font-size: x-large;
+  font-size: medium; /* Changed from x-large */
   font-weight: bold;
 }
 


### PR DESCRIPTION
- Modified `style/tailwind.css` to correctly adjust heading font sizes.
- Set `h1` to `xx-large`, `h2` to `x-large`, `h3` to `large`, and `h4` to `medium`.
- This ensures `h1` is smaller than its original size (when it was `xxx-large`) but still larger than `h2`, and maintains a consistent heading hierarchy.

This corrects a previous attempt that modified the wrong CSS file.